### PR TITLE
Remove debug banner from display

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       home: MyHomePage(),
     );
   }


### PR DESCRIPTION
This change removes the "DEBUG" banner that appears in the top-right corner of the application when running in debug mode. This was achieved by setting the `debugShowCheckedModeBanner` property to `false` in the `MaterialApp` widget constructor in `lib/main.dart`. This improves the visual appearance during development and testing without affecting release builds (where the banner is removed by default).

---
*PR created automatically by Jules for task [16442399195622913177](https://jules.google.com/task/16442399195622913177) started by @arran4*